### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,13 @@ test {
         showStackTraces true
         showStandardStreams = false
     }
+
+    jvmArgs '-ea'
 }
 
 application {
     mainClass = 'dukii.Launcher'
+    applicationDefaultJvmArgs = ['-ea']
 }
 
 shadowJar {

--- a/src/main/java/dukii/parser/Parser.java
+++ b/src/main/java/dukii/parser/Parser.java
@@ -50,6 +50,7 @@ public class Parser {
     private static final String LIST_COMMAND = "list";
     
     public Command parse(final String input) throws DukiiException {
+        assert input != null;
         String trimmed = input.trim();
         
         if (trimmed.equalsIgnoreCase(BYE_COMMAND)) {
@@ -91,6 +92,7 @@ public class Parser {
         }
         
         String[] parts = input.substring(DEADLINE_PREFIX.length()).trim().split(" by ");
+        assert parts != null;
         if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
             throw new DukiiException("Sweetie, I need both the task and when it's due! Try: deadline <description> by <time>");
         }
@@ -110,6 +112,7 @@ public class Parser {
         }
         
         String[] parts = input.substring(EVENT_PREFIX.length()).trim().split(" from ");
+        assert parts != null;
         if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
             throw new DukiiException("Hmm, I'm a bit confused! Please tell me: event <description> from <start_time> to <end_time>");
         }
@@ -119,6 +122,7 @@ public class Parser {
         }
         
         String[] timeParts = parts[1].trim().split(" to ");
+        assert timeParts != null;
         if (timeParts.length != 2 || timeParts[0].isEmpty() || timeParts[1].isEmpty()) {
             throw new DukiiException("Oops! I need the complete event details: event <description> from <start_time> to <end_time>");
         }

--- a/src/main/java/dukii/storage/Storage.java
+++ b/src/main/java/dukii/storage/Storage.java
@@ -55,6 +55,7 @@ public class Storage {
      * @param filePath the path to the file where tasks will be stored
      */
     public Storage(final String filePath) {
+        assert filePath != null && !filePath.isEmpty();
         this.filePath = filePath;
     }
 
@@ -73,6 +74,9 @@ public class Storage {
         final Path path = Path.of(filePath);
         final File file = path.toFile();
         
+        assert path != null;
+        assert file != null;
+
         if (!file.exists()) {
             createFileAndDirectories(file);
             return new ArrayList<>();
@@ -81,6 +85,9 @@ public class Storage {
         final List<String> lines = Files.readAllLines(path);
         final ArrayList<Task> tasks = new ArrayList<>();
         
+        assert lines != null;
+        assert tasks != null;
+
         for (String line : lines) {
             if (line == null || line.trim().isEmpty()) {
                 continue;
@@ -107,6 +114,7 @@ public class Storage {
      * @throws IOException if an error occurs during file operations
      */
     public void save(final List<Task> tasks) throws IOException {
+        assert tasks != null;
         final Path path = Path.of(filePath);
         final File file = path.toFile();
         final File parent = file.getParentFile();
@@ -117,6 +125,7 @@ public class Storage {
         
         try (FileWriter writer = new FileWriter(file)) {
             for (Task task : tasks) {
+                assert task != null;
                 writer.write(serializeTask(task));
                 writer.write(System.lineSeparator());
             }
@@ -143,6 +152,7 @@ public class Storage {
      * @return a string representation of the task for storage
      */
     private String serializeTask(final Task task) {
+        assert task != null;
         String status = task.isDone() ? TASK_STATUS_DONE : TASK_STATUS_PENDING;
         
         if (task instanceof ToDo) {
@@ -173,6 +183,7 @@ public class Storage {
      * @return the reconstructed Task object, or null if parsing fails
      */
     private Task parseTask(final String line) {
+        assert line != null;
         String[] parts = line.split("\\s*\\|\\s*");
         if (parts.length < TODO_MIN_PARTS) {
             return null;

--- a/src/main/java/dukii/task/TaskList.java
+++ b/src/main/java/dukii/task/TaskList.java
@@ -25,6 +25,7 @@ public class TaskList {
      * @param tasks the initial collection of tasks
      */
     public TaskList(ArrayList<Task> tasks) {
+        assert tasks != null;
         this.tasks = tasks;
     }
 
@@ -37,6 +38,7 @@ public class TaskList {
      * @return the ArrayList containing all tasks
      */
     public ArrayList<Task> asList() {
+        assert tasks != null;
         return tasks;
     }
     
@@ -49,10 +51,12 @@ public class TaskList {
     }
     
     public void addTask(Task task) {
+        assert task != null;
         tasks.add(task);
     }
     
     public Task getTask(int index) {
+        assert index >= 0;
         if (index < 0 || index >= tasks.size()) {
             return null;
         }
@@ -60,6 +64,7 @@ public class TaskList {
     }
     
     public void removeTask(int index) {
+        assert index >= 0;
         if (index >= 0 && index < tasks.size()) {
             tasks.remove(index);
         }


### PR DESCRIPTION
Parser, Storage, and TaskList lack internal checks for invalid inputs and invariants. Without assertions, programmer errors can go unnoticed until they surface as harder-to-debug failures later.

Let's

- add assertion checks for non-null inputs, valid indices, and expected parse results in Parser, Storage, and TaskList

- enable assertions for Gradle test and run tasks via '-ea'

- verify the build and tests pass with assertions enabled

This aligns with the A-Assertions increment and improves code quality by failing fast during development while keeping overhead off when assertions are disabled.